### PR TITLE
Fix typo in exit_status (#934)

### DIFF
--- a/locales/app.yml
+++ b/locales/app.yml
@@ -249,10 +249,10 @@ _version: 2
   en: "The Ultimate vimrc"
 "vim binary might be actually nvim":
   en: "vim binary might be actually nvim"
-"`{process}` failed: {exit_satus}":
-  en: "`%{process}` failed: %{exit_satus}"
-"`{process}` failed: {exit_satus} with {output}":
-  en: "`%{process}` failed: %{exit_satus} with %{output}"
+"`{process}` failed: {exit_status}":
+  en: "`%{process}` failed: %{exit_status}"
+"`{process}` failed: {exit_status} with {output}":
+  en: "`%{process}` failed: %{exit_status} with %{output}"
 "Unknown Linux Distribution":
   en: "Unknown Linux Distribution"
 'File "/etc/os-release" does not exist or is empty':

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,7 @@ impl Display for TopgradeError {
                     f,
                     "{}",
                     t!(
-                        "`{process}` failed: {exit_satus}",
+                        "`{process}` failed: {exit_status}",
                         process = process,
                         exit_status = exit_status
                     )
@@ -38,7 +38,7 @@ impl Display for TopgradeError {
                     f,
                     "{}",
                     t!(
-                        "`{process}` failed: {exit_satus} with {output}",
+                        "`{process}` failed: {exit_status} with {output}",
                         process = process,
                         exit_status = exit_status,
                         output = output


### PR DESCRIPTION
fix: typo in exit_status

## What does this PR do


## Standards checklist

- [ ] The PR title is descriptive.
- [ ] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself
 
## For new steps

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by 
  the underlying command

If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here.
